### PR TITLE
added io.h for windows build

### DIFF
--- a/src/spi_binding.cc
+++ b/src/spi_binding.cc
@@ -19,7 +19,11 @@
 #include "spi_binding.h"
 
 #include <stdio.h>
+#ifdef _WIN32
+#include <io.h>
+#else
 #include <unistd.h>
+#endif
 #include <fcntl.h>
 
 #ifdef __linux__


### PR DESCRIPTION
Seems to build on windows now, gives build message about using fake spi methods, which seems correct.