### PR TITLE
fix compilation error for node10

### DIFF
--- a/src/spi_binding.cc
+++ b/src/spi_binding.cc
@@ -102,7 +102,8 @@ SPI_FUNC_IMPL(New) {
     args.GetReturnValue().Set(args.This());
   } else {
     Local<Function> cons = Local<Function>::New(isolate, constructor);
-    args.GetReturnValue().Set(cons->NewInstance());
+    args.GetReturnValue().Set(cons->NewInstance(Isolate::GetCurrent()->GetCurrentContext(),
+                                                0, NULL).ToLocalChecked());
   }
 }
 


### PR DESCRIPTION
Allows compilation on newer versions of node which deprecates arg-less Function::NewInstance, and returns Maybe<> instead of Local<>